### PR TITLE
Fix ImportError with spyne 2.14.0 and update test/setup requirements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Requirements:
 
 * Python >= 3.7
 * Aiohttp >= 3.7.0
-* Spyne >= 2.13.16
+* Spyne >= 2.14.0
 
 Spyne alpha versions should also work.
 

--- a/aiohttp_spyne/aio_base.py
+++ b/aiohttp_spyne/aio_base.py
@@ -9,7 +9,7 @@ from aiohttp import web
 from spyne import Application
 from spyne.application import get_fault_string_from_exception
 from spyne.auxproc import process_contexts
-from spyne.interface import AllYourInterfaceDocuments
+from spyne.interface import InterfaceDocuments
 from spyne.model.fault import Fault
 from spyne.protocol.http import HttpRpc
 from spyne.server import ServerBase
@@ -103,7 +103,7 @@ class AioBase(ServerBase):
     def _generate_wsdl(self, req: web.Request) -> bytes:
         """Requests spyne to generate a new WSDL document"""
         actual_url = urlunparse([req.scheme, req.host, req.path, "", "", ""])
-        doc = AllYourInterfaceDocuments(self.app.interface)
+        doc = InterfaceDocuments(self.app.interface)
         doc.wsdl11.build_interface_document(actual_url)
         return doc.wsdl11.get_interface_document()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-aiohttp>=3.0.0,<4.0.0
-spyne==2.13.16
-pytest==6.2.5
+aiohttp>=3.7.0,<4.0.0
+spyne==2.14.0
+pytest==7.1.0
 zeep[async]==4.1.0
 flake8==4.0.1
-black==21.10b0
-mypy==0.910
-wheel==0.37.0
-twine==3.6.0
+black==22.1.0
+mypy==0.941
+wheel==0.37.1
+twine==3.8.0

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,5 @@ setup(
         "Framework :: AsyncIO",
     ],
     packages=["aiohttp_spyne"],
-    install_requires=["aiohttp>=3.0.0,<4.0.0", "spyne>=2.13.16"],
+    install_requires=["aiohttp>=3.7.0,<4.0.0", "spyne>=2.14.0"],
 )


### PR DESCRIPTION
Fixes #3.
This PR will replace the `AllYourInterfaceDocuments` import with `InterfaceDocuments` from the current version of spyne.

Tested locally in the following environment:
* Ubuntu 20.04.4 LTS
* Python 3.7